### PR TITLE
feat: save agentic report programmatically

### DIFF
--- a/evaluations/trajectory_specs.py
+++ b/evaluations/trajectory_specs.py
@@ -114,8 +114,8 @@ WRITER_TRAJECTORY_SPEC = {
             "id": "save_report",
             "type": "function_call",
             "name": "save_report",
-            "required": True,
-            "description": "Writer saves report to file",
+            "required": False,
+            "description": "Writer saves report to file (optional if saved programmatically)",
         },
     ]
 }
@@ -181,8 +181,8 @@ FULL_WORKFLOW_TRAJECTORY_SPEC = {
             "id": "writer_save",
             "type": "function_call",
             "name": "save_report",
-            "required": True,
-            "description": "Writer saves final report",
+            "required": False,
+            "description": "Writer saves final report (optional if saved programmatically)",
         },
     ]
 }

--- a/evaluations/write_agent_eval.py
+++ b/evaluations/write_agent_eval.py
@@ -88,7 +88,7 @@ def _prepare_writer_inputs(test_case: dict) -> tuple[list[str], list[str], Path]
     return agenda, prepared_files, temp_dir
 
 
-# ✅ ORDRE CORRIGÉ : read_multiple_files PUIS save_report PUIS generations
+# ✅ ORDRE CORRIGÉ : read_multiple_files PUIS générations (save_report optionnel)
 TRAJECTORY_SPEC = {
     "trajectory_spec": [
         {
@@ -118,7 +118,7 @@ TRAJECTORY_SPEC = {
             "expected_content": "## Report",
             "required": True,
         },
-        {"id": "save_report", "type": "function_call", "name": "save_report", "required": True},
+        {"id": "save_report", "type": "function_call", "name": "save_report", "required": False},
     ]
 }
 

--- a/src/agentic_manager.py
+++ b/src/agentic_manager.py
@@ -10,7 +10,7 @@ from .agents.file_search_agent import create_file_search_agent
 from .agents.file_search_planning_agent import create_file_planner_agent
 from .agents.file_writer_agent import create_writer_agent
 from .agents.schemas import ReportData, ResearchInfo
-from .agents.utils import coerce_report_data
+from .agents.utils import coerce_report_data, save_final_report_function
 from .config import get_config
 from .printer import Printer
 
@@ -78,6 +78,16 @@ class AgenticResearchManager:
             self.printer.update_item("final_report", final_report, is_done=True)
 
             self.printer.end()
+
+        print("\n\n=====SAVING REPORT=====\n\n")
+        _new_report = await save_final_report_function(
+            research_info.output_dir,
+            report.research_topic,
+            report.markdown_report,
+            report.short_summary,
+            report.follow_up_questions,
+        )
+        print(f"Report saved: {_new_report.file_name}")
 
         print("\n\n=====REPORT=====\n\n")
         print(f"Report: {report.markdown_report}")

--- a/tests/test_agentic_manager_save.py
+++ b/tests/test_agentic_manager_save.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import pytest
+
+from src.agentic_manager import AgenticResearchManager
+from src.agents.schemas import ReportData, ResearchInfo
+
+
+class DummyServer:
+    pass
+
+
+@pytest.mark.asyncio
+async def test_agentic_manager_saves_report(monkeypatch, tmp_path):
+    report = ReportData(
+        file_name="report.md",
+        research_topic="Topic",
+        short_summary="Short summary",
+        markdown_report="# Report",
+        follow_up_questions=["Q1"],
+    )
+
+    async def fake_agentic_research(self, _query, _research_info):
+        return report
+
+    save_calls: list[tuple] = []
+
+    async def fake_save_final_report_function(
+        output_dir, research_topic, markdown_report, short_summary, follow_up_questions
+    ):
+        save_calls.append(
+            (output_dir, research_topic, markdown_report, short_summary, follow_up_questions)
+        )
+        return report
+
+    monkeypatch.setattr(AgenticResearchManager, "_agentic_research", fake_agentic_research)
+    monkeypatch.setattr(
+        "src.agentic_manager.save_final_report_function",
+        fake_save_final_report_function,
+        raising=False,
+    )
+    monkeypatch.setattr("src.agentic_manager.create_file_planner_agent", lambda *_a, **_k: object())
+    monkeypatch.setattr("src.agentic_manager.create_file_search_agent", lambda *_a, **_k: object())
+    monkeypatch.setattr("src.agentic_manager.create_writer_agent", lambda *_a, **_k: object())
+    monkeypatch.setattr(
+        "src.agentic_manager.create_research_supervisor_agent", lambda *_a, **_k: object()
+    )
+
+    research_info = ResearchInfo(
+        vector_store_name="store",
+        vector_store_id=None,
+        temp_dir=str(tmp_path),
+        max_search_plan="1-2",
+        output_dir=str(tmp_path / "out"),
+    )
+
+    manager = AgenticResearchManager()
+    await manager.run(
+        fs_server=DummyServer(),
+        dataprep_server=DummyServer(),
+        vector_mcp_server=None,
+        query="<research_request>Q</research_request>",
+        research_info=research_info,
+    )
+
+    assert save_calls == [(str(tmp_path / "out"), "Topic", "# Report", "Short summary", ["Q1"])]

--- a/tests/test_trajectory_specs.py
+++ b/tests/test_trajectory_specs.py
@@ -99,9 +99,12 @@ def test_writer_trajectory_spec_checkpoints():
     assert "report_generation_report" in checkpoint_ids
     assert "save_report" in checkpoint_ids
 
-    # Verify all are required
+    # Verify required flags (save_report is optional when saved programmatically)
     for checkpoint in trajectory:
-        assert checkpoint["required"] is True
+        if checkpoint["id"] == "save_report":
+            assert checkpoint["required"] is False
+        else:
+            assert checkpoint["required"] is True
 
 
 def test_full_workflow_trajectory_spec_structure():


### PR DESCRIPTION
Summary
Save agentic_manager reports programmatically (same behavior as deep_manager) and relax evaluation trajectory expectations to allow optional save_report when saving is handled outside the writer agent. Adds unit test coverage for agentic_manager save path and updates trajectory spec test accordingly.

Testing
poetry run ruff check .
poetry run ruff format --check .
poetry run pytest
poetry run pytest integration_tests (fails in integration_tests/test_mcp_dataprep.py::TestMCPDataprepIntegration::test_knowledge_database_model_validation; unrelated)

Issue
Closes #68