### PR TITLE
feat: validate inputs and support file_id fallback

### DIFF
--- a/src/dataprep/mcp_functions.py
+++ b/src/dataprep/mcp_functions.py
@@ -11,6 +11,7 @@ from .knowledge_db import KnowledgeDBManager
 from .models import KnowledgeEntry, UploadResult
 from .vector_backends import get_vector_backend
 from .vector_search import VectorSearchResult
+from .vector_store_utils import validate_url
 from .web_loader_improved import load_documents_from_urls
 
 logger = logging.getLogger(__name__)
@@ -27,6 +28,7 @@ def download_and_store_url(url: str, config) -> str:
     Returns:
         str: Nom du fichier local (.md)
     """
+    validate_url(url)
     # 1. Lookup dans knowledge_db.json
     db_manager = KnowledgeDBManager(config.data.knowledge_db_path)
     existing_entry = db_manager.lookup_url(url)

--- a/src/dataprep/vector_store_utils.py
+++ b/src/dataprep/vector_store_utils.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import re
 import shutil
 from pathlib import Path
+from urllib.parse import urlparse
 
 from .knowledge_db import KnowledgeDBManager
 from .models import KnowledgeEntry
@@ -39,6 +41,41 @@ def ensure_local_file_entry(
     return entry
 
 
+def is_openai_file_id(value: str) -> bool:
+    return bool(re.match(r"^file[-_][A-Za-z0-9]+$", value))
+
+
+def validate_url(url: str) -> None:
+    if not url:
+        raise ValueError("URL vide")
+    if any(ch.isspace() for ch in url):
+        raise ValueError(f"URL invalide (espaces): {url}")
+    try:
+        url.encode("ascii")
+    except UnicodeEncodeError as exc:
+        raise ValueError(f"URL invalide (non ASCII): {url}") from exc
+    parsed = urlparse(url)
+    if parsed.scheme not in {"http", "https"}:
+        raise ValueError(f"URL invalide (schema): {url}")
+    if not parsed.netloc:
+        raise ValueError(f"URL invalide (domaine manquant): {url}")
+
+
+def validate_filename(filename: str) -> None:
+    if not filename:
+        raise ValueError("Nom de fichier vide")
+    if "/" in filename or "\\" in filename:
+        raise ValueError(f"Nom de fichier invalide (separateurs): {filename}")
+    if filename.startswith(".") or filename in {".", ".."}:
+        raise ValueError(f"Nom de fichier invalide: {filename}")
+    if ".." in filename:
+        raise ValueError(f"Nom de fichier invalide (path traversal): {filename}")
+    if len(filename) > 255:
+        raise ValueError(f"Nom de fichier trop long: {filename}")
+    if not re.match(r"^[A-Za-z0-9._-]+$", filename):
+        raise ValueError(f"Nom de fichier invalide (caracteres): {filename}")
+
+
 def resolve_inputs_to_entries(
     inputs: list[str],
     config,
@@ -52,13 +89,23 @@ def resolve_inputs_to_entries(
 
         input_path = Path(input_item)
 
-        if input_path.exists():
+        if is_openai_file_id(input_item):
+            entry = db_manager.find_by_openai_file_id(input_item)
+            if not entry:
+                raise ValueError(f"file_id non trouvé dans la base de connaissances: {input_item}")
+        elif input_path.exists():
+            if input_path.is_dir():
+                raise ValueError(f"Chemin invalide (dossier): {input_item}")
             entry = ensure_local_file_entry(input_path, config, db_manager)
         elif input_item.startswith(("http://", "https://")):
+            validate_url(input_item)
             entry = db_manager.lookup_url(input_item)
             if not entry:
                 raise ValueError(f"URL non trouvée dans la base de connaissances: {input_item}")
+        elif "://" in input_item:
+            raise ValueError(f"URL invalide (schema): {input_item}")
         else:
+            validate_filename(input_item)
             entry = db_manager.find_by_name(input_item)
             if not entry:
                 candidate_path = local_dir / input_item

--- a/tests/test_dataprep_input_validation.py
+++ b/tests/test_dataprep_input_validation.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from src.dataprep.knowledge_db import KnowledgeDBManager
+from src.dataprep.models import KnowledgeEntry
+from src.dataprep.vector_store_utils import (
+    is_openai_file_id,
+    resolve_inputs_to_entries,
+    validate_filename,
+    validate_url,
+)
+
+
+def _reset_db_manager():
+    KnowledgeDBManager._instance = None
+    KnowledgeDBManager._url_index = {}
+    KnowledgeDBManager._name_index = {}
+    KnowledgeDBManager._openai_file_id_index = {}
+
+
+def _make_config(tmp_path):
+    return SimpleNamespace(
+        data=SimpleNamespace(
+            local_storage_dir=str(tmp_path / "storage"),
+            knowledge_db_path=tmp_path / "knowledge_db.json",
+        )
+    )
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://example.com",
+        "http://example.com/path?x=1",
+    ],
+)
+def test_validate_url_accepts_valid_urls(url):
+    validate_url(url)
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "ftp://example.com",
+        "http://",
+        "example.com",
+        "https://exämple.com",
+        "https://example.com/white space",
+    ],
+)
+def test_validate_url_rejects_invalid_urls(url):
+    with pytest.raises(ValueError):
+        validate_url(url)
+
+
+@pytest.mark.parametrize(
+    "filename",
+    [
+        "file.txt",
+        "file_name-1.md",
+        "report",
+    ],
+)
+def test_validate_filename_accepts_valid_filenames(filename):
+    validate_filename(filename)
+
+
+@pytest.mark.parametrize(
+    "filename",
+    [
+        "../file.txt",
+        "dir/file.txt",
+        "dir\\file.txt",
+        "/abs/path.txt",
+        "file name.txt",
+        "..",
+        ".hidden",
+    ],
+)
+def test_validate_filename_rejects_invalid_filenames(filename):
+    with pytest.raises(ValueError):
+        validate_filename(filename)
+
+
+def test_is_openai_file_id():
+    assert is_openai_file_id("file-abc123")
+    assert is_openai_file_id("file_ABC123")
+    assert not is_openai_file_id("file")
+    assert not is_openai_file_id("file-")
+    assert not is_openai_file_id("not-file-abc")
+
+
+def test_resolve_inputs_supports_openai_file_id(tmp_path):
+    _reset_db_manager()
+    config = _make_config(tmp_path)
+    local_dir = tmp_path / "storage"
+    local_dir.mkdir(parents=True, exist_ok=True)
+    (local_dir / "doc.md").write_text("content", encoding="utf-8")
+
+    db_manager = KnowledgeDBManager(config.data.knowledge_db_path)
+    entry = KnowledgeEntry(
+        url="file://doc.md",
+        filename="doc.md",
+        keywords=[],
+        summary=None,
+        openai_file_id="file-abc123",
+    )
+    db_manager.add_entry(entry)
+
+    resolved = resolve_inputs_to_entries(
+        ["file-abc123"],
+        config,
+        db_manager,
+        local_dir,
+    )
+
+    assert len(resolved) == 1
+    resolved_entry, resolved_path = resolved[0]
+    assert resolved_entry.filename == "doc.md"
+    assert resolved_path == local_dir / "doc.md"
+
+
+def test_resolve_inputs_rejects_unknown_file_id(tmp_path):
+    _reset_db_manager()
+    config = _make_config(tmp_path)
+    local_dir = tmp_path / "storage"
+    local_dir.mkdir(parents=True, exist_ok=True)
+    db_manager = KnowledgeDBManager(config.data.knowledge_db_path)
+
+    with pytest.raises(ValueError):
+        resolve_inputs_to_entries(
+            ["file-unknown"],
+            config,
+            db_manager,
+            local_dir,
+        )


### PR DESCRIPTION
Summary
Implement S2+S3: strict URL/filename validation and file_id fallback via knowledge DB in dataprep (no new MCP tool). Adds unit tests covering validations and file_id resolution.

Testing
poetry run ruff check .
poetry run ruff format --check .
poetry run pytest
poetry run pytest tests/test_dataprep_input_validation.py
poetry run pytest integration_tests (fails if DGX ctx server unavailable)

Issue
Closes #82
