### PR TITLE
chore: set OpenAI defaults in config

### DIFF
--- a/configs/config-default.yaml
+++ b/configs/config-default.yaml
@@ -3,8 +3,8 @@ config_name: "default (mixed models)"
 
 vector_store:
   # OpenAI Vector Store ID - https://platform.openai.com/storage/vector_stores/
-  name: "agent-engineer-basic-course"
-  description: "Vector store for agentic research experiments"
+  name: "agentic-research-default"
+  description: "Vector store for agentic research."
   expires_after_days: 30
 
 vector_search:
@@ -55,9 +55,9 @@ mcp:
 # Configuration Models
 models:
   research_model: "openai/gpt-4.1-mini"
-  planning_model: "litellm/mistral/magistral-small-2509"
+  planning_model: "openai/gpt-4.1-mini"
   search_model: "openai/gpt-4.1-mini" # GPT-4.1-mini is required for file search tool (vector_search.provider = openai)
-  writer_model: "litellm/mistral/mistral-small-latest"
+  writer_model: "openai/gpt-4.1-mini"
   knowledge_preparation_model: "openai/gpt-4.1-mini"
 
 # Configuration du manager


### PR DESCRIPTION
## Summary
Set configs/config-default.yaml to use OpenAI defaults for both LLM and vector store.

## Testing
- Not run (config-only)
