### PR TITLE
feat: block report generation when no search results are produced

### DIFF
--- a/src/agents/agentic_research_agent.py
+++ b/src/agents/agentic_research_agent.py
@@ -7,6 +7,7 @@ from agents import Agent, RunContextWrapper, RunResult, ToolCallOutputItem, hand
 
 from ..config import get_config
 from ..dataprep.vector_backends import get_vector_backend
+from ..gates import check_search_results_gate
 from .file_writer_agent import WriterDirective
 from .schemas import ReportData, ResearchInfo
 from .utils import (
@@ -52,6 +53,7 @@ def create_research_supervisor_agent(
 ):
     def on_handoff(ctx: RunContextWrapper[ResearchInfo], directive: WriterDirective):
         print(f"Writer agent called with directive: {directive}")
+        check_search_results_gate(directive.search_results)
         ctx.context.search_results = directive.search_results
 
     config = get_config()

--- a/src/deep_research_manager.py
+++ b/src/deep_research_manager.py
@@ -24,6 +24,7 @@ from .agents.schemas import (
 )
 from .agents.utils import coerce_report_data, save_final_report_function
 from .config import get_config
+from .gates import check_search_results_gate
 from .printer import Printer
 
 
@@ -150,6 +151,9 @@ class DeepResearchManager:
             search_start = time.time()
             search_results = await self._perform_file_searches(search_plan)
             self.timings["search"] = time.time() - search_start
+
+            # Gate: block report if no exploitable source was produced
+            check_search_results_gate(search_results)
 
             # Phase 4: Writing
             write_start = time.time()

--- a/src/gates.py
+++ b/src/gates.py
@@ -1,0 +1,30 @@
+"""Programmatic gate checks for the research workflow.
+
+These gates enforce hard invariants that must hold before
+the workflow can proceed to the next phase.
+"""
+
+from __future__ import annotations
+
+
+class NoSearchResultsError(ValueError):
+    """Raised when the research phase produced no exploitable results."""
+
+
+def check_search_results_gate(search_results: list[str | None]) -> None:
+    """Block report generation if no exploitable search result was produced.
+
+    Args:
+        search_results: List of file paths from the search phase.
+            May contain None entries for failed individual searches.
+
+    Raises:
+        NoSearchResultsError: If no valid (non-None) result exists.
+    """
+    valid = [r for r in search_results if r is not None]
+    if not valid:
+        raise NoSearchResultsError(
+            "No exploitable search results were produced. "
+            "Cannot generate a report without sources. "
+            "The run is marked as incomplete."
+        )

--- a/src/manager.py
+++ b/src/manager.py
@@ -13,6 +13,7 @@ from .agents.schemas import ReportData, ResearchInfo
 from .agents.search_agent import search_agent
 from .agents.utils import coerce_report_data
 from .agents.writer_agent import writer_agent
+from .gates import check_search_results_gate
 from .printer import Printer
 
 
@@ -45,6 +46,10 @@ class StandardResearchManager:
             )
             search_plan = await self._plan_searches(query)
             search_results = await self._perform_searches(search_plan)
+
+            # Gate: block report if no exploitable source was produced
+            check_search_results_gate(search_results)
+
             report = await self._write_report(query, search_results)
 
             final_report = f"Report summary\n\n{report.short_summary}"

--- a/tests/test_no_source_gate.py
+++ b/tests/test_no_source_gate.py
@@ -1,0 +1,48 @@
+"""Tests for the no-source gate: no report should be produced without search results."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.agents.schemas import ResearchInfo
+from src.gates import NoSearchResultsError, check_search_results_gate
+
+
+class TestNoSourceGate:
+    """Gate function must raise when search results are empty or all None."""
+
+    def _make_research_info(self) -> ResearchInfo:
+        return ResearchInfo(
+            vector_store_id="vs_test",
+            temp_dir="/tmp/test",
+            max_search_plan="3-5",
+            output_dir="output/",
+        )
+
+    def test_empty_list_raises(self):
+        with pytest.raises(NoSearchResultsError):
+            check_search_results_gate([])
+
+    def test_all_none_raises(self):
+        with pytest.raises(NoSearchResultsError):
+            check_search_results_gate([None, None, None])
+
+    def test_valid_results_pass(self):
+        # Should not raise
+        check_search_results_gate(["/tmp/test/result1.txt", "/tmp/test/result2.txt"])
+
+    def test_mixed_with_some_none_passes(self):
+        # Some None results are acceptable as long as at least one is valid
+        check_search_results_gate([None, "/tmp/test/result1.txt", None])
+
+    def test_single_valid_result_passes(self):
+        check_search_results_gate(["/tmp/test/result.txt"])
+
+    def test_error_message_is_descriptive(self):
+        with pytest.raises(NoSearchResultsError, match=r"No exploitable search results"):
+            check_search_results_gate([])
+
+    def test_error_is_value_error_subclass(self):
+        """Ensure callers catching ValueError also catch this."""
+        with pytest.raises(ValueError):
+            check_search_results_gate([])


### PR DESCRIPTION
## Summary

- Add a programmatic gate (`src/gates.py`) that raises `NoSearchResultsError` when no exploitable search results exist
- Integrate the gate in all 3 manager implementations:
  - **DeepResearchManager**: between search phase and write phase
  - **StandardResearchManager**: between search and write
  - **AgenticResearchManager**: in the writer `on_handoff` callback (before the supervisor hands off to the writer agent)
- Runs with no sources are now clearly marked as failures instead of producing false positive reports

## Test plan

- [x] 7 unit tests (TDD — written before implementation)
- [x] Empty list raises `NoSearchResultsError`
- [x] All-None list raises
- [x] Mixed list (some None, some valid) passes
- [x] Single valid result passes
- [x] Error is a `ValueError` subclass for backward compatibility
- [x] All 159 tests pass (152 existing + 7 new)
- [x] Lint clean

Fixes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)