### PR TITLE
fix: strengthen no-source gate to check file content (run_2 bug)

### DIFF
--- a/src/gates.py
+++ b/src/gates.py
@@ -6,6 +6,12 @@ the workflow can proceed to the next phase.
 
 from __future__ import annotations
 
+import os
+
+# Minimum content size in bytes to consider a search result file exploitable.
+# Files at or below this threshold are treated as empty/trivial.
+_MIN_CONTENT_BYTES = 50
+
 
 class NoSearchResultsError(ValueError):
     """Raised when the research phase produced no exploitable results."""
@@ -14,17 +20,40 @@ class NoSearchResultsError(ValueError):
 def check_search_results_gate(search_results: list[str | None]) -> None:
     """Block report generation if no exploitable search result was produced.
 
+    Checks two levels:
+    1. At least one non-None file path must exist in the results.
+    2. At least one of those files must exist on disk and contain
+       meaningful content (more than a trivial number of bytes).
+
     Args:
         search_results: List of file paths from the search phase.
             May contain None entries for failed individual searches.
 
     Raises:
-        NoSearchResultsError: If no valid (non-None) result exists.
+        NoSearchResultsError: If no valid, non-empty result exists.
     """
-    valid = [r for r in search_results if r is not None]
-    if not valid:
+    valid_paths = [r for r in search_results if r is not None]
+    if not valid_paths:
         raise NoSearchResultsError(
             "No exploitable search results were produced. "
             "Cannot generate a report without sources. "
+            "The run is marked as incomplete."
+        )
+
+    exploitable = 0
+    for path in valid_paths:
+        try:
+            size = os.path.getsize(path)
+            if size > _MIN_CONTENT_BYTES:
+                exploitable += 1
+        except OSError:
+            # File does not exist or is inaccessible — skip it.
+            continue
+
+    if exploitable == 0:
+        raise NoSearchResultsError(
+            f"Search produced {len(valid_paths)} file(s), but none contain "
+            f"exploitable content (>{_MIN_CONTENT_BYTES} bytes). "
+            "Cannot generate a report without substantive sources. "
             "The run is marked as incomplete."
         )

--- a/tests/test_no_source_gate.py
+++ b/tests/test_no_source_gate.py
@@ -2,22 +2,15 @@
 
 from __future__ import annotations
 
+import os
+
 import pytest
 
-from src.agents.schemas import ResearchInfo
 from src.gates import NoSearchResultsError, check_search_results_gate
 
 
-class TestNoSourceGate:
-    """Gate function must raise when search results are empty or all None."""
-
-    def _make_research_info(self) -> ResearchInfo:
-        return ResearchInfo(
-            vector_store_id="vs_test",
-            temp_dir="/tmp/test",
-            max_search_plan="3-5",
-            output_dir="output/",
-        )
+class TestNoSourceGateNoPaths:
+    """Gate must raise when search results list is empty or all None."""
 
     def test_empty_list_raises(self):
         with pytest.raises(NoSearchResultsError):
@@ -27,17 +20,6 @@ class TestNoSourceGate:
         with pytest.raises(NoSearchResultsError):
             check_search_results_gate([None, None, None])
 
-    def test_valid_results_pass(self):
-        # Should not raise
-        check_search_results_gate(["/tmp/test/result1.txt", "/tmp/test/result2.txt"])
-
-    def test_mixed_with_some_none_passes(self):
-        # Some None results are acceptable as long as at least one is valid
-        check_search_results_gate([None, "/tmp/test/result1.txt", None])
-
-    def test_single_valid_result_passes(self):
-        check_search_results_gate(["/tmp/test/result.txt"])
-
     def test_error_message_is_descriptive(self):
         with pytest.raises(NoSearchResultsError, match=r"No exploitable search results"):
             check_search_results_gate([])
@@ -46,3 +28,67 @@ class TestNoSourceGate:
         """Ensure callers catching ValueError also catch this."""
         with pytest.raises(ValueError):
             check_search_results_gate([])
+
+
+class TestNoSourceGateFileContent:
+    """Gate must raise when files exist but contain no meaningful content."""
+
+    def _write_file(self, tmp: str, name: str, content: str) -> str:
+        path = os.path.join(tmp, name)
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(content)
+        return path
+
+    def test_valid_file_passes(self, tmp_path):
+        path = self._write_file(str(tmp_path), "result.txt", "A" * 200)
+        check_search_results_gate([path])
+
+    def test_mixed_with_some_none_and_valid_file_passes(self, tmp_path):
+        path = self._write_file(str(tmp_path), "result.txt", "A" * 200)
+        check_search_results_gate([None, path, None])
+
+    def test_empty_files_raise(self, tmp_path):
+        path = self._write_file(str(tmp_path), "empty.txt", "")
+        with pytest.raises(NoSearchResultsError, match=r"none contain exploitable content"):
+            check_search_results_gate([path])
+
+    def test_trivially_small_files_raise(self, tmp_path):
+        """Files with <50 bytes are considered trivial (e.g. just a header)."""
+        path = self._write_file(str(tmp_path), "tiny.txt", "short")
+        with pytest.raises(NoSearchResultsError):
+            check_search_results_gate([path])
+
+    def test_multiple_empty_files_raise(self, tmp_path):
+        paths = [
+            self._write_file(str(tmp_path), f"empty_{i}.txt", "")
+            for i in range(3)
+        ]
+        with pytest.raises(NoSearchResultsError, match=r"3 file\(s\)"):
+            check_search_results_gate(paths)
+
+    def test_one_valid_among_empty_passes(self, tmp_path):
+        """At least one file with real content is enough."""
+        empty = self._write_file(str(tmp_path), "empty.txt", "")
+        valid = self._write_file(str(tmp_path), "good.txt", "X" * 100)
+        check_search_results_gate([empty, valid])
+
+    def test_nonexistent_files_treated_as_empty(self, tmp_path):
+        fake_path = os.path.join(str(tmp_path), "does_not_exist.txt")
+        with pytest.raises(NoSearchResultsError):
+            check_search_results_gate([fake_path])
+
+    def test_mix_nonexistent_and_valid_passes(self, tmp_path):
+        fake = os.path.join(str(tmp_path), "nope.txt")
+        valid = self._write_file(str(tmp_path), "good.txt", "Y" * 100)
+        check_search_results_gate([fake, valid])
+
+    def test_boundary_exactly_threshold_raises(self, tmp_path):
+        """File with exactly 50 bytes should NOT pass (must be strictly greater)."""
+        path = self._write_file(str(tmp_path), "boundary.txt", "Z" * 50)
+        with pytest.raises(NoSearchResultsError):
+            check_search_results_gate([path])
+
+    def test_boundary_above_threshold_passes(self, tmp_path):
+        """File with 51 bytes should pass."""
+        path = self._write_file(str(tmp_path), "ok.txt", "Z" * 51)
+        check_search_results_gate([path])

--- a/tests/test_no_source_gate_integration.py
+++ b/tests/test_no_source_gate_integration.py
@@ -1,0 +1,137 @@
+"""Integration test reproducing the run_2 bug: search agents return file paths
+but the files contain no real content from vector_search.
+
+The DeepResearchManager should raise NoSearchResultsError instead of
+producing a false-positive report.
+
+Bug observed in benchmarks/run_2 (2026-03-13):
+- 4 file_search_agents ran, 0 failures reported
+- 3 files written to temp_dir, but with empty/trivial content
+- Writer produced a report saying "No files were attached for this query"
+- LLM-as-judge gave PASS with all A grades
+- context_relevance was 0.3 (no actual retrieved sources)
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.agents.schemas import FileSearchItem, FileSearchPlan, ResearchInfo
+from src.deep_research_manager import DeepResearchManager
+from src.gates import NoSearchResultsError
+
+
+@pytest.fixture
+def research_info(tmp_path):
+    return ResearchInfo(
+        vector_store_id="vs_test",
+        temp_dir=str(tmp_path),
+        max_search_plan="3-5",
+        output_dir=str(tmp_path / "output"),
+    )
+
+
+@pytest.fixture
+def search_plan():
+    """A search plan similar to what run_2 produced."""
+    return FileSearchPlan(
+        searches=[
+            FileSearchItem(query="prompt engineering techniques", reason="Module 1 coverage"),
+            FileSearchItem(query="RAG retrieval augmented generation", reason="Module 2 coverage"),
+            FileSearchItem(query="multi agent systems", reason="Module 3 coverage"),
+            FileSearchItem(query="ChatGPT API integration", reason="Module 4 coverage"),
+        ]
+    )
+
+
+def _create_empty_search_results(tmp_path, count=3):
+    """Simulate what run_2 produced: files exist but contain no real content.
+
+    In the actual bug, vector_search returned nothing useful, so the
+    file_search_agent wrote files with trivial or no content.
+    """
+    results = []
+    for i in range(count):
+        path = os.path.join(str(tmp_path), f"search_result_{i}.txt")
+        with open(path, "w", encoding="utf-8") as f:
+            # Empty or trivially small — like the run_2 files
+            f.write("")
+        results.append(path)
+    # One search returned None (failed silently)
+    results.append(None)
+    return results
+
+
+def _create_valid_search_results(tmp_path, count=3):
+    """Simulate a healthy run with real content in search result files."""
+    results = []
+    for i in range(count):
+        path = os.path.join(str(tmp_path), f"search_result_{i}.txt")
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(f"Search result {i}\n\n" + "Substantive research content. " * 20)
+        results.append(path)
+    return results
+
+
+class TestRun2BugReproduction:
+    """Reproduce the exact failure mode from benchmarks/run_2."""
+
+    @pytest.mark.asyncio
+    async def test_empty_search_files_block_writer(self, tmp_path, research_info, search_plan):
+        """The core bug: search 'succeeds' but files are empty.
+
+        The manager must raise NoSearchResultsError instead of calling _write_report.
+        """
+        manager = DeepResearchManager()
+        empty_results = _create_empty_search_results(tmp_path)
+
+        # Mock the phases that precede the gate:
+        # - _prepare_knowledge returns an agenda string
+        # - _plan_file_searches returns the search plan
+        # - _perform_file_searches returns file paths (the bug: files exist but empty)
+        # We do NOT mock _write_report — it must never be called
+        with (
+            patch.object(manager, "_prepare_knowledge", new_callable=AsyncMock, return_value="Test agenda"),
+            patch.object(manager, "_plan_file_searches", new_callable=AsyncMock, return_value=search_plan),
+            patch.object(manager, "_perform_file_searches", new_callable=AsyncMock, return_value=empty_results),
+            patch.object(manager, "_write_report", new_callable=AsyncMock) as mock_write,
+        ):
+            fs_server = MagicMock()
+            dataprep_server = MagicMock()
+
+            with pytest.raises(NoSearchResultsError, match=r"none contain exploitable content"):
+                await manager.run(fs_server, dataprep_server, "<research_request>test</research_request>", research_info)
+
+            # The writer must NEVER have been called
+            mock_write.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_valid_search_files_proceed_to_writer(self, tmp_path, research_info, search_plan):
+        """Control test: when files have real content, writer IS called."""
+        manager = DeepResearchManager()
+        valid_results = _create_valid_search_results(tmp_path)
+
+        mock_report = MagicMock()
+        mock_report.short_summary = "Test summary"
+        mock_report.research_topic = "Test"
+        mock_report.markdown_report = "# Test"
+        mock_report.follow_up_questions = []
+        mock_report.file_name = "test.md"
+
+        with (
+            patch.object(manager, "_prepare_knowledge", new_callable=AsyncMock, return_value="Test agenda"),
+            patch.object(manager, "_plan_file_searches", new_callable=AsyncMock, return_value=search_plan),
+            patch.object(manager, "_perform_file_searches", new_callable=AsyncMock, return_value=valid_results),
+            patch.object(manager, "_write_report", new_callable=AsyncMock, return_value=mock_report) as mock_write,
+            patch("src.deep_research_manager.save_final_report_function", new_callable=AsyncMock, return_value=mock_report),
+        ):
+            fs_server = MagicMock()
+            dataprep_server = MagicMock()
+
+            await manager.run(fs_server, dataprep_server, "<research_request>test</research_request>", research_info)
+
+            # Writer MUST have been called exactly once
+            mock_write.assert_called_once()


### PR DESCRIPTION
## Summary

- Strengthen the no-source gate (#145) to detect the false-positive case observed in **benchmarks/run_2**: search agents return file paths (0 failures reported), but the files are empty because vector_search found nothing relevant. The writer then produces a report saying "No files were attached" while the LLM-as-judge gives PASS with all A grades.
- The gate now checks that at least one result file exists on disk **and** contains more than 50 bytes of content
- Add integration test reproducing the exact run_2 failure mode (TDD: test written first, verified to fail with old gate, then verified to pass with fix)

## Root cause analysis (from benchmarks/run_2)

```
agent_calls.failures: 0          ← no exception thrown
context_relevance: 0.3           ← nothing useful retrieved  
quality_result.judgment: PASS    ← LLM judge fooled
report: "No files were attached" ← writer admits it has no sources
```

The original gate only checked for non-None file paths → it let this through.

## Test plan

- [x] Integration test: mock DeepResearchManager phases, inject empty files → `NoSearchResultsError` raised, `_write_report` never called
- [x] Integration test (control): inject files with real content → `_write_report` called
- [x] Test verified to **FAIL** with the original gate (path-only check)
- [x] Test verified to **PASS** with the strengthened gate (file content check)
- [x] 14 unit tests on gate function (empty, trivial, boundary, nonexistent, mixed)
- [x] All 168 tests pass
- [x] Lint clean

Relates to #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)