### PR TITLE
fix(manager): handle plain-string final_output from file_search_agent

### DIFF
--- a/src/deep_research_manager.py
+++ b/src/deep_research_manager.py
@@ -18,7 +18,6 @@ from .agents.knowledge_preparation_agent import create_knowledge_preparation_age
 from .agents.schemas import (
     FileSearchItem,
     FileSearchPlan,
-    FileSearchResult,
     ReportData,
     ResearchInfo,
 )
@@ -281,7 +280,9 @@ class DeepResearchManager:
             self._record_usage(result, phase="search")
             self.agent_calls["file_search_agent"] += 1
             self.agent_calls["total"] += 1
-            raw_file_name = str(result.final_output_as(FileSearchResult).file_name)
+            # file_search_agent has no output_type (dropped in 2f35b47); per
+            # its prompt it returns the bare filename as final_output text.
+            raw_file_name = str(result.final_output or "").strip()
             normalized_path = self._normalize_search_result_path(raw_file_name)
             if normalized_path is None:
                 self.agent_calls["failures"] += 1

--- a/tests/test_deep_research_manager_paths.py
+++ b/tests/test_deep_research_manager_paths.py
@@ -69,6 +69,81 @@ def test_normalize_search_result_path_handles_long_filenames(tmp_path: Path):
 
 
 @pytest.mark.asyncio
+async def test_file_search_returns_normalized_path_for_plain_string_output(
+    monkeypatch, tmp_path: Path
+):
+    """file_search_agent has no output_type (dropped in commit 2f35b47) — its
+    final_output is a plain string containing the filename. _file_search must
+    accept that and resolve it to the absolute path. Previously the manager
+    called result.final_output_as(FileSearchResult).file_name, which raises
+    AttributeError on a str and the `except Exception` silently returned None,
+    making search_results empty and the writer receive "Search results: None".
+    """
+    manager = _build_manager(tmp_path)
+    manager.file_search_agent = object()
+
+    # Simulate file written by the agent via its MCP write_file tool.
+    summary_file = tmp_path / "mips_vs_rewoo.txt"
+    summary_file.write_text("summary", encoding="utf-8")
+
+    class _FakeResult:
+        def __init__(self, output):
+            self.final_output = output
+
+        def final_output_as(self, cls):
+            from typing import cast
+
+            return cast(cls, self.final_output)
+
+    async def _fake_run(agent, input_text, context):
+        del agent, input_text, context
+        # Agent obeys file_search_prompt.md ("return only the name of the file"):
+        # final_output is a plain string, not a FileSearchResult.
+        return _FakeResult("mips_vs_rewoo.txt")
+
+    monkeypatch.setattr("src.deep_research_manager.Runner.run", _fake_run)
+    monkeypatch.setattr(manager, "_record_usage", lambda *a, **k: None)
+
+    result_path = await manager._file_search(
+        FileSearchItem(query="mips rewoo", reason="comparison")
+    )
+
+    assert result_path == str(summary_file.resolve()), (
+        f"Expected normalized temp path, got {result_path!r}"
+    )
+    assert manager.agent_calls["failures"] == 0
+
+
+@pytest.mark.asyncio
+async def test_file_search_returns_none_for_empty_output(monkeypatch, tmp_path: Path):
+    """When the agent returns an empty / whitespace final_output, _file_search
+    should mark a failure and return None (no silent fake-success)."""
+    manager = _build_manager(tmp_path)
+    manager.file_search_agent = object()
+
+    class _FakeResult:
+        def __init__(self, output):
+            self.final_output = output
+
+        def final_output_as(self, cls):
+            from typing import cast
+
+            return cast(cls, self.final_output)
+
+    async def _fake_run(agent, input_text, context):
+        del agent, input_text, context
+        return _FakeResult("   ")
+
+    monkeypatch.setattr("src.deep_research_manager.Runner.run", _fake_run)
+    monkeypatch.setattr(manager, "_record_usage", lambda *a, **k: None)
+
+    result_path = await manager._file_search(FileSearchItem(query="foo", reason="bar"))
+
+    assert result_path is None
+    assert manager.agent_calls["failures"] == 1
+
+
+@pytest.mark.asyncio
 async def test_plan_file_searches_retries_once_on_invalid_json(monkeypatch, tmp_path: Path):
     manager = _build_manager(tmp_path)
     manager.file_planner_agent = object()


### PR DESCRIPTION
## Problem

`DeepResearchManager._file_search` calls:

\`\`\`python
raw_file_name = str(result.final_output_as(FileSearchResult).file_name)
\`\`\`

But \`file_search_agent\` has had **no** \`output_type\` declared since commit \`2f35b47\` (\"drop structured output for file_search_agent\"). So \`result.final_output\` is the plain string the agent returns, per \`file_search_prompt.md\`:

> In your final reply, return only the name of the file \`<filename>.txt\`

The SDK's \`final_output_as\` is only a typechecker cast (see \`openai-agents/result.py\` L107-123), so \`.file_name\` on a plain \`str\` raises \`AttributeError\`. The bare \`except Exception:\` in \`_file_search\` silently swallows it and returns \`None\`.

Effect: every file search is booked as a failure, \`search_results\` stays empty, and the writer receives \"Search results: None\" and falls back to a placeholder report.

### Why was this invisible until now?

On the llama.cpp baseline the writer agent calls \`list_directory\` on the temp dir on its own initiative and re-discovers files despite the empty list. The gpt-oss-20b model served by vLLM does not take that initiative, and the regression surfaced during WS1 end-to-end validation.

## Fix

- Read \`result.final_output\` directly as string (prompt contract guarantees it).
- Drop the now-unused \`FileSearchResult\` import.

## Tests

- \`test_file_search_returns_normalized_path_for_plain_string_output\` — RED-then-GREEN test reproducing the bug (agent returns \`\"mips_vs_rewoo.txt\"\`, manager must resolve to the absolute temp path instead of \`None\`).
- \`test_file_search_returns_none_for_empty_output\` — ensures whitespace-only output is not accepted as a fake success.

All 8 tests in \`test_deep_research_manager_paths.py\` pass. Full \`uv run pytest\` (154 tests) + \`uv run ruff check .\` stay green.

## Integration validation

End-to-end workflow verified on DGX Spark with vLLM mono gpt-oss-20b (branch \`ws1/inference-platform\`, WS1 step 5'). With the fix, the workflow:
- Passes all search result paths to the writer agent.
- Produces an exploitable report grounded in the retrieved files.

## Notes

- The related \`vector_search\` tool has a separate small-model robustness issue (\`filenames: str\` instead of \`filenames: list[str]\`) that will be addressed in a follow-up PR.
- No changes to \`file_search_agent\` or its prompt — the fix restores consistency between the agent (plain-string output) and its consumer (the manager).