### PR TITLE
feat(#164): allow per-endpoint API override (chat_completions vs responses)

### DIFF
--- a/src/agents/utils.py
+++ b/src/agents/utils.py
@@ -360,24 +360,45 @@ def extract_model_name(model_string: Any) -> str:
     return model_string
 
 
-def _extract_endpoint_fields(model_spec: Any) -> tuple[str | None, str | None, str | None]:
+def _extract_endpoint_fields(
+    model_spec: Any,
+) -> tuple[str | None, str | None, str | None, str | None]:
     if isinstance(model_spec, dict) and "name" in model_spec:
         return (
             str(model_spec["name"]),
             model_spec.get("base_url"),
             model_spec.get("api_key"),
+            model_spec.get("api"),
         )
     if hasattr(model_spec, "name"):
         return (
             str(getattr(model_spec, "name")),
             getattr(model_spec, "base_url", None),
             getattr(model_spec, "api_key", None),
+            getattr(model_spec, "api", None),
         )
-    return None, None, None
+    return None, None, None, None
+
+
+def _default_openai_api(base_url: str | None, api_key: str | None) -> str | None:
+    """Pick the default API for an openai/ spec when no explicit override is set.
+
+    - base_url present → Chat Completions (issue #158: most local OpenAI-compatible
+      servers historically only spoke /v1/chat/completions).
+    - api_key present, no base_url → Responses (cloud OpenAI default).
+    - Neither → None, signaling "fall through to bare-string passthrough".
+    """
+    if base_url:
+        return "chat_completions"
+    if api_key:
+        return "responses"
+    return None
 
 
 def resolve_model(model_spec: Any):
     """Dispatch a model spec to the right Agents SDK model class.
+
+    Default dispatch (when ModelEndpointConfig.api is None):
 
     | name prefix       | base_url | api_key | resolved type                       |
     |-------------------|----------|---------|-------------------------------------|
@@ -386,33 +407,39 @@ def resolve_model(model_spec: Any):
     | openai/<name>     | no       | no      | bare name (SDK default Response API)|
     | litellm/<prov>/.. | any      | any     | LitellmModel                        |
 
-    See issue #158: routing local OpenAI-compatible endpoints (vLLM, llama.cpp)
-    through LiteLLM masks native OpenAI parameters. The openai/+base_url path
-    must use AsyncOpenAI directly with a per-model client (Option B), so each
-    agent can independently target local infra or third-party APIs. When an
-    api_key is provided without a base_url (cloud OpenAI with a per-agent key,
-    e.g. multi-org/multi-project setups), build a Responses model with a custom
-    AsyncOpenAI client so the key is honored instead of falling back to env.
+    Issue #164 — explicit `api: "chat_completions" | "responses"` on the spec
+    overrides the default for the openai/ path. Required for vLLM serving
+    gpt-oss, which exposes /v1/responses and needs Responses API to surface
+    the `reasoning` field cleanly. Override on the openai/ alone case forces
+    a concrete class wrapping AsyncOpenAI() (env-only api key).
+
+    The override is ignored on the litellm/ path — LiteLLM handles its own
+    routing.
+
+    Issue #158 background: routing local OpenAI-compatible endpoints (vLLM,
+    llama.cpp) through LiteLLM masks native OpenAI parameters. Each agent
+    gets its own AsyncOpenAI client (Option B) so research_model can target
+    local infra while writer_model targets a third-party API in parallel.
     """
     if isinstance(model_spec, (LitellmModel, OpenAIChatCompletionsModel, OpenAIResponsesModel)):
         return model_spec
 
-    name, base_url, api_key = _extract_endpoint_fields(model_spec)
+    name, base_url, api_key, api_override = _extract_endpoint_fields(model_spec)
     if name is None:
         return model_spec
 
-    if name.startswith("openai/"):
-        bare = name[len("openai/") :]
-        if base_url:
-            client = AsyncOpenAI(base_url=base_url, api_key=api_key)
-            return OpenAIChatCompletionsModel(model=bare, openai_client=client)
-        if api_key:
-            client = AsyncOpenAI(api_key=api_key)
-            return OpenAIResponsesModel(model=bare, openai_client=client)
-        return name
-
     if name.startswith("litellm/"):
         return LitellmModel(model=name, base_url=base_url, api_key=api_key)
+
+    if name.startswith("openai/"):
+        bare = name[len("openai/") :]
+        chosen_api = api_override or _default_openai_api(base_url, api_key)
+        if chosen_api is None:
+            return name
+        client = AsyncOpenAI(base_url=base_url, api_key=api_key)
+        if chosen_api == "responses":
+            return OpenAIResponsesModel(model=bare, openai_client=client)
+        return OpenAIChatCompletionsModel(model=bare, openai_client=client)
 
     return model_spec
 

--- a/src/config.py
+++ b/src/config.py
@@ -125,6 +125,7 @@ class ModelEndpointConfig(BaseModel):
     name: str
     base_url: str | None = None
     api_key: str | None = None
+    api: Literal["chat_completions", "responses"] | None = None
 
 
 ModelSpec = str | ModelEndpointConfig

--- a/tests/test_resolve_model_api_override.py
+++ b/tests/test_resolve_model_api_override.py
@@ -120,7 +120,10 @@ class TestApiOverrideOnBareCloud:
     back to the OPENAI_API_KEY env var. Without the override we keep the bare
     string passthrough."""
 
-    def test_chat_completions_override_on_bare_cloud(self):
+    def test_chat_completions_override_on_bare_cloud(self, monkeypatch):
+        # AsyncOpenAI() requires a key from config or env; isolate the test
+        # from the developer's .env so it behaves the same in CI.
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-env-fallback")
         spec = ModelEndpointConfig(
             name="openai/gpt-4.1-mini",
             api="chat_completions",
@@ -135,7 +138,8 @@ class TestApiOverrideOnBareCloud:
         assert isinstance(model._client, AsyncOpenAI)
         assert model.model == "gpt-4.1-mini"
 
-    def test_responses_override_on_bare_cloud(self):
+    def test_responses_override_on_bare_cloud(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-env-fallback")
         spec = ModelEndpointConfig(
             name="openai/gpt-4.1-mini",
             api="responses",

--- a/tests/test_resolve_model_api_override.py
+++ b/tests/test_resolve_model_api_override.py
@@ -1,0 +1,204 @@
+"""TDD red tests for issue #164 — per-endpoint API override.
+
+Documents the expected behavior of resolve_model() once the new `api` field
+on ModelEndpointConfig is honored.
+
+Today the dispatch is hardcoded:
+- openai/+base_url            → OpenAIChatCompletionsModel
+- openai/+api_key (no bu)     → OpenAIResponsesModel
+- openai/ alone               → bare string passthrough
+
+After #164, an explicit `api: "chat_completions" | "responses"` on the spec
+overrides this default, so e.g. gpt-oss on vLLM can opt into Responses API
+(needed to expose the `reasoning` field cleanly).
+
+Sanity tests (api=None) confirm that current behavior is preserved.
+"""
+
+from __future__ import annotations
+
+from agents.extensions.models.litellm_model import LitellmModel
+from openai import AsyncOpenAI
+
+from agents import OpenAIChatCompletionsModel, OpenAIResponsesModel
+from src.agents.utils import resolve_model
+from src.config import ModelEndpointConfig
+
+
+class TestApiOverrideOnLocalEndpoint:
+    """openai/+base_url with explicit api override.
+
+    Use case: vLLM serving gpt-oss exposes /v1/responses; we want to opt in
+    to Responses API instead of the default Chat Completions choice.
+    """
+
+    def test_responses_override_on_local_endpoint(self):
+        spec = ModelEndpointConfig(
+            name="openai/gpt-oss-20b",
+            base_url="http://vllm:8004/v1",
+            api_key="dummy",
+            api="responses",
+        )
+
+        model = resolve_model(spec)
+
+        assert isinstance(model, OpenAIResponsesModel), (
+            f"Expected OpenAIResponsesModel for explicit api='responses' on a "
+            f"local endpoint (gpt-oss/vLLM use case), got {type(model).__name__}."
+        )
+        assert isinstance(model._client, AsyncOpenAI)
+        assert str(model._client.base_url).rstrip("/").startswith("http://vllm:8004")
+        assert model._client.api_key == "dummy"
+        assert model.model == "gpt-oss-20b"
+
+    def test_chat_completions_override_on_local_endpoint_is_explicit_default(self):
+        """Sanity: passing the current default explicitly must keep working."""
+        spec = ModelEndpointConfig(
+            name="openai/local-llm",
+            base_url="http://llama-cpp-cpu:8002",
+            api_key="dummy",
+            api="chat_completions",
+        )
+
+        model = resolve_model(spec)
+
+        assert isinstance(model, OpenAIChatCompletionsModel)
+
+    def test_no_override_on_local_endpoint_preserves_chat_completions_default(self):
+        """Sanity: api=None preserves current behavior (Chat Completions for
+        openai/+base_url). Already passes today, must keep passing."""
+        spec = ModelEndpointConfig(
+            name="openai/local-llm",
+            base_url="http://llama-cpp-cpu:8002",
+            api_key="dummy",
+        )
+
+        model = resolve_model(spec)
+
+        assert isinstance(model, OpenAIChatCompletionsModel)
+
+
+class TestApiOverrideOnCloudWithKey:
+    """openai/+api_key (no base_url) with explicit api override."""
+
+    def test_chat_completions_override_on_cloud_with_key(self):
+        """Edge case: cloud OpenAI but the user wants Chat Completions
+        (legacy code, specific feature)."""
+        spec = ModelEndpointConfig(
+            name="openai/gpt-4.1-mini",
+            api_key="sk-custom",
+            api="chat_completions",
+        )
+
+        model = resolve_model(spec)
+
+        assert isinstance(model, OpenAIChatCompletionsModel), (
+            f"Expected OpenAIChatCompletionsModel for explicit api='chat_completions', "
+            f"got {type(model).__name__}."
+        )
+        assert isinstance(model._client, AsyncOpenAI)
+        assert model._client.api_key == "sk-custom"
+        assert model.model == "gpt-4.1-mini"
+
+    def test_no_override_on_cloud_with_key_preserves_responses_default(self):
+        """Sanity: api=None preserves current behavior (Responses for cloud+key).
+        Already passes today, must keep passing."""
+        spec = ModelEndpointConfig(
+            name="openai/gpt-4.1-mini",
+            api_key="sk-custom",
+        )
+
+        model = resolve_model(spec)
+
+        assert isinstance(model, OpenAIResponsesModel)
+
+
+class TestApiOverrideOnBareCloud:
+    """openai/<n> alone (no base_url, no api_key) with explicit api override.
+
+    The override forces a concrete class wrapping AsyncOpenAI(), which falls
+    back to the OPENAI_API_KEY env var. Without the override we keep the bare
+    string passthrough."""
+
+    def test_chat_completions_override_on_bare_cloud(self):
+        spec = ModelEndpointConfig(
+            name="openai/gpt-4.1-mini",
+            api="chat_completions",
+        )
+
+        model = resolve_model(spec)
+
+        assert isinstance(model, OpenAIChatCompletionsModel), (
+            f"Expected OpenAIChatCompletionsModel for explicit api override "
+            f"on bare cloud spec, got {type(model).__name__}."
+        )
+        assert isinstance(model._client, AsyncOpenAI)
+        assert model.model == "gpt-4.1-mini"
+
+    def test_responses_override_on_bare_cloud(self):
+        spec = ModelEndpointConfig(
+            name="openai/gpt-4.1-mini",
+            api="responses",
+        )
+
+        model = resolve_model(spec)
+
+        assert isinstance(model, OpenAIResponsesModel)
+        assert isinstance(model._client, AsyncOpenAI)
+        assert model.model == "gpt-4.1-mini"
+
+    def test_no_override_on_bare_cloud_preserves_passthrough(self):
+        """Sanity: api=None keeps the bare-string passthrough. Already passes
+        today, must keep passing."""
+        spec = ModelEndpointConfig(name="openai/gpt-4.1-mini")
+
+        model = resolve_model(spec)
+
+        assert model == "openai/gpt-4.1-mini"
+
+
+class TestApiOverrideIgnoredOnLitellm:
+    """The api field is meaningless on the litellm/ path — LiteLLM handles its
+    own routing. We must NOT try to wrap litellm specs in OpenAI*Model."""
+
+    def test_responses_override_on_litellm_still_returns_litellm(self):
+        spec = ModelEndpointConfig(
+            name="litellm/mistral/mistral-medium-latest",
+            api_key="key",
+            api="responses",
+        )
+
+        model = resolve_model(spec)
+
+        assert isinstance(model, LitellmModel), (
+            "litellm/ prefix must always resolve to LitellmModel; the api "
+            "override only applies to the openai/ path."
+        )
+
+    def test_chat_completions_override_on_litellm_still_returns_litellm(self):
+        spec = ModelEndpointConfig(
+            name="litellm/anthropic/claude-3-7-sonnet-20250219",
+            api_key="key",
+            api="chat_completions",
+        )
+
+        model = resolve_model(spec)
+
+        assert isinstance(model, LitellmModel)
+
+
+class TestApiOverrideViaDictSpec:
+    """Dict-shaped specs (used by some call sites) must also honor the override."""
+
+    def test_dict_with_responses_override(self):
+        spec = {
+            "name": "openai/gpt-oss-20b",
+            "base_url": "http://vllm:8004/v1",
+            "api_key": "dummy",
+            "api": "responses",
+        }
+
+        model = resolve_model(spec)
+
+        assert isinstance(model, OpenAIResponsesModel)
+        assert model.model == "gpt-oss-20b"


### PR DESCRIPTION
## Summary

- Adds optional `api: "chat_completions" | "responses" | None` field on `ModelEndpointConfig`. Default `None` preserves the post-#158 dispatch (full backwards compat).
- `resolve_model()` honors the override on the `openai/` path, ignored on the `litellm/` path (LiteLLM does its own routing).
- Unblocks gpt-oss on vLLM via Responses API (vLLM exposes `/v1/responses` for gpt-oss; OpenAI recommends Responses to surface the `reasoning` field).

## Dispatch table (with override)

| name prefix | base_url | api_key | `api` override | resolved type |
|---|---|---|---|---|
| `openai/<n>` | ✓ | any | `responses` | `OpenAIResponsesModel` + client(base_url) |
| `openai/<n>` | ✓ | any | none / `chat_completions` | `OpenAIChatCompletionsModel` + client |
| `openai/<n>` | ✗ | ✓ | `chat_completions` | `OpenAIChatCompletionsModel` + client |
| `openai/<n>` | ✗ | ✓ | none / `responses` | `OpenAIResponsesModel` + client |
| `openai/<n>` | ✗ | ✗ | `chat_completions` / `responses` | concrete class wrapping `AsyncOpenAI()` (env-only key) |
| `openai/<n>` | ✗ | ✗ | none | bare-string passthrough (SDK default) |
| `litellm/<n>` | any | any | any | `LitellmModel` (override ignored) |

## Example YAML

```yaml
research_model:
  name: "openai/gpt-oss-20b"
  base_url: "http://vllm:8004/v1"
  api_key: "dummy"
  api: "responses"          # opt-in vLLM/Responses for gpt-oss
```

## TDD process

- **RED** (`a80e400`): adds `api` field on `ModelEndpointConfig` + 11 tests covering all combinations. 5 fail (new behavior), 6 pass (sanity preservation + litellm/ ignore).
- **GREEN** (`17d1494`): `resolve_model()` honors the override via a small helper `_default_openai_api()` that factors the implicit pre-#164 default. 29/29 green on the resolve_model bloc.

## Why not `set_default_openai_api`

It's a process-wide singleton. With a per-endpoint field we keep the Option B independence validated in #158: research_model in Responses on vLLM/gpt-oss while writer_model is in Chat Completions on llama.cpp/Mistral, in parallel.

## Test plan

- [x] `uv run pytest tests/test_resolve_model_*.py` → 29/29 pass
- [x] `uv run pytest` → 193 passed / 2 skipped
- [x] `uv run ruff check .` and `uv run ruff format --check .` → clean
- [ ] Manual smoke run with a vLLM/gpt-oss config carrying `api: "responses"` to confirm the `reasoning` field surfaces

Fixes #164