### PR TITLE
feat(#170): per-agent reasoning_effort and verbosity

### DIFF
--- a/src/agents/agentic_research_agent.py
+++ b/src/agents/agentic_research_agent.py
@@ -12,6 +12,7 @@ from .file_writer_agent import WriterDirective
 from .schemas import ReportData, ResearchInfo
 from .utils import (
     adjust_model_settings_for_base_url,
+    apply_endpoint_model_settings,
     display_agenda,
     enable_usage_for_litellm,
     extract_model_name,
@@ -79,6 +80,7 @@ def create_research_supervisor_agent(
     model_settings = get_default_model_settings(model_name)
     adjust_model_settings_for_base_url(research_model_spec, model_settings)
     enable_usage_for_litellm(research_model_spec, model_settings)
+    apply_endpoint_model_settings(research_model_spec, model_settings)
 
     search_tool_name = get_vector_backend(config).tool_name()
 

--- a/src/agents/file_search_agent.py
+++ b/src/agents/file_search_agent.py
@@ -8,6 +8,7 @@ from ..config import get_config
 from .schemas import ResearchInfo
 from .utils import (
     adjust_model_settings_for_base_url,
+    apply_endpoint_model_settings,
     enable_usage_for_litellm,
     extract_model_name,
     load_prompt_from_file,
@@ -53,6 +54,7 @@ def create_file_search_agent(
     model_settings = get_default_model_settings(model_name)
     adjust_model_settings_for_base_url(model_spec, model_settings)
     enable_usage_for_litellm(model_spec, model_settings)
+    apply_endpoint_model_settings(model_spec, model_settings)
 
     if config.vector_search.provider == "openai":
         tools = [FileSearchTool(vector_store_ids=[vector_store_id])]

--- a/src/agents/file_search_planning_agent.py
+++ b/src/agents/file_search_planning_agent.py
@@ -8,6 +8,7 @@ from ..config import get_config
 from .schemas import FileSearchPlan, ResearchInfo
 from .utils import (
     adjust_model_settings_for_base_url,
+    apply_endpoint_model_settings,
     enable_usage_for_litellm,
     extract_model_name,
     load_prompt_from_file,
@@ -53,6 +54,7 @@ def create_file_planner_agent(mcp_servers: list[MCPServer] | None = None):
     model_settings = get_default_model_settings(model_name)
     adjust_model_settings_for_base_url(model_spec, model_settings)
     enable_usage_for_litellm(model_spec, model_settings)
+    apply_endpoint_model_settings(model_spec, model_settings)
 
     return Agent(
         name="file_planner_agent",

--- a/src/agents/file_writer_agent.py
+++ b/src/agents/file_writer_agent.py
@@ -12,6 +12,7 @@ from ..config import get_config
 from .schemas import ResearchInfo
 from .utils import (
     adjust_model_settings_for_base_url,
+    apply_endpoint_model_settings,
     enable_usage_for_litellm,
     extract_model_name,
     get_writer_output_formatting,
@@ -105,6 +106,7 @@ def create_writer_agent(mcp_servers: list[MCPServer] | None = None, do_save_repo
     model_settings = get_default_model_settings(model_name)
     adjust_model_settings_for_base_url(model_spec, model_settings)
     enable_usage_for_litellm(model_spec, model_settings)
+    apply_endpoint_model_settings(model_spec, model_settings)
 
     writer_agent = Agent(
         name="writer_agent",

--- a/src/agents/knowledge_preparation_agent.py
+++ b/src/agents/knowledge_preparation_agent.py
@@ -9,6 +9,7 @@ from ..config import get_config
 from .schemas import ResearchInfo
 from .utils import (
     adjust_model_settings_for_base_url,
+    apply_endpoint_model_settings,
     display_agenda,
     enable_usage_for_litellm,
     extract_model_name,
@@ -57,6 +58,7 @@ def create_knowledge_preparation_agent(mcp_servers: list[MCPServer] | None = Non
     model_settings = get_default_model_settings(model_name)
     adjust_model_settings_for_base_url(model_spec, model_settings)
     enable_usage_for_litellm(model_spec, model_settings)
+    apply_endpoint_model_settings(model_spec, model_settings)
 
     knowledge_preparation_agent = Agent(
         name="knowledge_preparation_agent",

--- a/src/agents/qa_agent.py
+++ b/src/agents/qa_agent.py
@@ -8,7 +8,12 @@ from agents import Agent, RunContextWrapper
 
 from ..config import get_config
 from .schemas import ResearchInfo
-from .utils import adjust_model_settings_for_base_url, extract_model_name, resolve_model
+from .utils import (
+    adjust_model_settings_for_base_url,
+    apply_endpoint_model_settings,
+    extract_model_name,
+    resolve_model,
+)
 from .vector_search_tool import vector_search
 
 
@@ -27,6 +32,7 @@ def create_qa_agent():
     model_name = extract_model_name(model_spec)
     model_settings = get_default_model_settings(model_name)
     adjust_model_settings_for_base_url(model_spec, model_settings)
+    apply_endpoint_model_settings(model_spec, model_settings)
 
     return Agent(
         name="qa_agent",

--- a/src/agents/utils.py
+++ b/src/agents/utils.py
@@ -444,6 +444,37 @@ def resolve_model(model_spec: Any):
     return model_spec
 
 
+def _extract_reasoning_and_verbosity(
+    model_spec: Any,
+) -> tuple[str | None, str | None]:
+    if isinstance(model_spec, dict):
+        return model_spec.get("reasoning_effort"), model_spec.get("verbosity")
+    if hasattr(model_spec, "name"):
+        return (
+            getattr(model_spec, "reasoning_effort", None),
+            getattr(model_spec, "verbosity", None),
+        )
+    return None, None
+
+
+def apply_endpoint_model_settings(model_spec: Any, model_settings) -> None:
+    """Graft per-endpoint reasoning_effort/verbosity onto a ModelSettings.
+
+    Issue #170 — agents need per-endpoint reasoning controls (gpt-oss on vLLM,
+    o-series, gpt-5). Each is forwarded as-is by the SDK; no family detection
+    or clamping here (YAGNI — the YAML pins one endpoint per agent).
+    """
+    reasoning_effort, verbosity = _extract_reasoning_and_verbosity(model_spec)
+
+    if reasoning_effort is not None:
+        from openai.types.shared.reasoning import Reasoning
+
+        model_settings.reasoning = Reasoning(effort=reasoning_effort)
+
+    if verbosity is not None:
+        model_settings.verbosity = verbosity
+
+
 def adjust_model_settings_for_base_url(model_spec: Any, model_settings) -> None:
     """Apply LiteLLM-only compatibility settings for self-hosted endpoints.
 

--- a/src/config.py
+++ b/src/config.py
@@ -126,6 +126,8 @@ class ModelEndpointConfig(BaseModel):
     base_url: str | None = None
     api_key: str | None = None
     api: Literal["chat_completions", "responses"] | None = None
+    reasoning_effort: Literal["none", "low", "medium", "high"] | None = None
+    verbosity: Literal["low", "medium", "high"] | None = None
 
 
 ModelSpec = str | ModelEndpointConfig

--- a/src/config.py
+++ b/src/config.py
@@ -126,7 +126,7 @@ class ModelEndpointConfig(BaseModel):
     base_url: str | None = None
     api_key: str | None = None
     api: Literal["chat_completions", "responses"] | None = None
-    reasoning_effort: Literal["none", "low", "medium", "high"] | None = None
+    reasoning_effort: Literal["none", "minimal", "low", "medium", "high", "xhigh"] | None = None
     verbosity: Literal["low", "medium", "high"] | None = None
 
 

--- a/tests/test_reasoning_effort_verbosity.py
+++ b/tests/test_reasoning_effort_verbosity.py
@@ -1,0 +1,246 @@
+"""TDD red tests for issue #170 — per-agent reasoning_effort and verbosity.
+
+Documents the expected behavior of ModelEndpointConfig.reasoning_effort and
+ModelEndpointConfig.verbosity once the agent factories graft them onto
+ModelSettings.
+
+Today the factories build ModelSettings via get_default_model_settings() and
+never look at the new fields, so .reasoning and .verbosity stay None even when
+the spec sets them. After #170:
+
+- spec.reasoning_effort -> model_settings.reasoning = Reasoning(effort=...)
+- spec.verbosity        -> model_settings.verbosity = "<level>"
+
+Scope: openai/ specs (gpt-oss/vLLM, o-series, gpt-5). On litellm/ specs the
+fields are also forwarded — LiteLLM passes reasoning_effort through for
+supported providers — but family-specific behavior is out of scope (no
+adapter, no clamping per #170 design discussion).
+
+The helper is named `apply_endpoint_model_settings()` and lives in
+src/agents/utils.py next to adjust_model_settings_for_base_url().
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from agents.model_settings import ModelSettings
+
+from src.agents.utils import apply_endpoint_model_settings
+from src.config import Config, ModelEndpointConfig, VectorStoreConfig
+
+# ---------------------------------------------------------------------------
+# Unit tests on the helper (apply_endpoint_model_settings)
+# ---------------------------------------------------------------------------
+
+
+class TestApplyEndpointModelSettings:
+    """Helper grafts reasoning_effort/verbosity from a spec onto ModelSettings."""
+
+    def test_reasoning_effort_grafted_from_pydantic_spec(self):
+        spec = ModelEndpointConfig(
+            name="openai/gpt-oss-20b",
+            base_url="http://vllm:8004/v1",
+            api_key="dummy",
+            api="responses",
+            reasoning_effort="high",
+        )
+        ms = ModelSettings()
+
+        apply_endpoint_model_settings(spec, ms)
+
+        assert ms.reasoning is not None, (
+            "Helper must instantiate Reasoning(effort=...) when reasoning_effort is set."
+        )
+        assert ms.reasoning.effort == "high"
+
+    def test_verbosity_grafted_from_pydantic_spec(self):
+        spec = ModelEndpointConfig(
+            name="openai/gpt-5-mini",
+            api_key="sk-test",
+            verbosity="low",
+        )
+        ms = ModelSettings()
+
+        apply_endpoint_model_settings(spec, ms)
+
+        assert ms.verbosity == "low"
+
+    def test_both_fields_grafted_together(self):
+        spec = ModelEndpointConfig(
+            name="openai/gpt-oss-20b",
+            base_url="http://vllm:8004/v1",
+            api_key="dummy",
+            api="responses",
+            reasoning_effort="medium",
+            verbosity="high",
+        )
+        ms = ModelSettings()
+
+        apply_endpoint_model_settings(spec, ms)
+
+        assert ms.reasoning is not None and ms.reasoning.effort == "medium"
+        assert ms.verbosity == "high"
+
+    def test_no_fields_set_leaves_settings_unchanged(self):
+        spec = ModelEndpointConfig(
+            name="openai/local-llm",
+            base_url="http://llama-cpp-cpu:8002",
+            api_key="dummy",
+        )
+        ms = ModelSettings()
+
+        apply_endpoint_model_settings(spec, ms)
+
+        assert ms.reasoning is None
+        assert ms.verbosity is None
+
+    def test_dict_spec_supported(self):
+        """Dict-shaped specs (used by some call sites / tests) must work too."""
+        spec = {
+            "name": "openai/gpt-oss-20b",
+            "base_url": "http://vllm:8004/v1",
+            "api_key": "dummy",
+            "api": "responses",
+            "reasoning_effort": "low",
+            "verbosity": "medium",
+        }
+        ms = ModelSettings()
+
+        apply_endpoint_model_settings(spec, ms)
+
+        assert ms.reasoning is not None and ms.reasoning.effort == "low"
+        assert ms.verbosity == "medium"
+
+    def test_bare_string_spec_is_noop(self):
+        """Plain string model spec ('openai/gpt-4.1-mini') has no fields to graft."""
+        ms = ModelSettings()
+
+        apply_endpoint_model_settings("openai/gpt-4.1-mini", ms)
+
+        assert ms.reasoning is None
+        assert ms.verbosity is None
+
+    def test_none_effort_is_grafted_explicitly(self):
+        """`reasoning_effort='none'` is a meaningful value (gpt-5.1 default,
+        gpt-oss "no thinking" mode), not the same as omitting the field."""
+        spec = ModelEndpointConfig(
+            name="openai/gpt-5-1",
+            api_key="sk-test",
+            reasoning_effort="none",
+        )
+        ms = ModelSettings()
+
+        apply_endpoint_model_settings(spec, ms)
+
+        assert ms.reasoning is not None
+        assert ms.reasoning.effort == "none"
+
+    def test_existing_reasoning_settings_preserved_when_field_absent(self):
+        """If the helper is called on settings that already carry reasoning
+        from another source, it must not clobber them when the spec is silent."""
+        from openai.types.shared.reasoning import Reasoning
+
+        spec = ModelEndpointConfig(
+            name="openai/local-llm",
+            base_url="http://llama-cpp-cpu:8002",
+            api_key="dummy",
+        )
+        ms = ModelSettings(reasoning=Reasoning(effort="low"), verbosity="high")
+
+        apply_endpoint_model_settings(spec, ms)
+
+        assert ms.reasoning is not None and ms.reasoning.effort == "low"
+        assert ms.verbosity == "high"
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — factories must call the helper
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def docker_dgx_like_config(tmp_path):
+    """Mirror configs/config-docker-dgx.yaml — every model on a vLLM endpoint
+    with reasoning_effort/verbosity set, so we can prove every factory grafts
+    them onto its agent's ModelSettings."""
+    config = Config(
+        config_name="test-docker-dgx",
+        vector_store=VectorStoreConfig(name="test-vs"),
+    )
+    vllm_endpoint = ModelEndpointConfig(
+        name="openai/gpt-oss-20b",
+        base_url="http://vllm:8004/v1",
+        api_key="dummy",
+        api="responses",
+        reasoning_effort="high",
+        verbosity="medium",
+    )
+    config.models.research_model = vllm_endpoint
+    config.models.planning_model = vllm_endpoint
+    config.models.search_model = vllm_endpoint
+    config.models.writer_model = vllm_endpoint
+    config.models.knowledge_preparation_model = vllm_endpoint
+    config.agents.output_dir = str(tmp_path)
+    config.agents.writer_output_format = "markdown"
+    config.vector_search.provider = "chroma"
+    return config
+
+
+def _assert_reasoning_and_verbosity_grafted(agent):
+    ms = agent.model_settings
+    assert ms.reasoning is not None, (
+        f"Agent {agent.name!r} did not graft reasoning from spec.reasoning_effort. "
+        f"Expected ModelSettings.reasoning.effort='high'."
+    )
+    assert ms.reasoning.effort == "high"
+    assert ms.verbosity == "medium", (
+        f"Agent {agent.name!r} did not graft verbosity from spec.verbosity. "
+        f"Expected 'medium', got {ms.verbosity!r}."
+    )
+
+
+def test_planner_agent_grafts_reasoning_and_verbosity(docker_dgx_like_config):
+    from src.agents import file_search_planning_agent as mod
+
+    with patch.object(mod, "get_config", return_value=docker_dgx_like_config):
+        agent = mod.create_file_planner_agent()
+
+    _assert_reasoning_and_verbosity_grafted(agent)
+
+
+def test_file_search_agent_grafts_reasoning_and_verbosity(docker_dgx_like_config):
+    from src.agents import file_search_agent as mod
+
+    with patch.object(mod, "get_config", return_value=docker_dgx_like_config):
+        agent = mod.create_file_search_agent(vector_store_id="vs_test")
+
+    _assert_reasoning_and_verbosity_grafted(agent)
+
+
+def test_writer_agent_grafts_reasoning_and_verbosity(docker_dgx_like_config):
+    from src.agents import file_writer_agent as mod
+
+    with patch.object(mod, "get_config", return_value=docker_dgx_like_config):
+        agent = mod.create_writer_agent()
+
+    _assert_reasoning_and_verbosity_grafted(agent)
+
+
+def test_knowledge_preparation_agent_grafts_reasoning_and_verbosity(docker_dgx_like_config):
+    from src.agents import knowledge_preparation_agent as mod
+
+    with patch.object(mod, "get_config", return_value=docker_dgx_like_config):
+        agent = mod.create_knowledge_preparation_agent()
+
+    _assert_reasoning_and_verbosity_grafted(agent)
+
+
+def test_qa_agent_grafts_reasoning_and_verbosity(docker_dgx_like_config):
+    from src.agents import qa_agent as mod
+
+    with patch.object(mod, "get_config", return_value=docker_dgx_like_config):
+        agent = mod.create_qa_agent()
+
+    _assert_reasoning_and_verbosity_grafted(agent)

--- a/tests/test_reasoning_effort_verbosity.py
+++ b/tests/test_reasoning_effort_verbosity.py
@@ -122,6 +122,36 @@ class TestApplyEndpointModelSettings:
         assert ms.reasoning is None
         assert ms.verbosity is None
 
+    def test_minimal_effort_grafted(self):
+        """`minimal` is supported by the SDK Reasoning enum (gpt-5.x families).
+        Config must accept it and the helper must forward it as-is."""
+        spec = ModelEndpointConfig(
+            name="openai/gpt-5-mini",
+            api_key="sk-test",
+            reasoning_effort="minimal",
+        )
+        ms = ModelSettings()
+
+        apply_endpoint_model_settings(spec, ms)
+
+        assert ms.reasoning is not None
+        assert ms.reasoning.effort == "minimal"
+
+    def test_xhigh_effort_grafted(self):
+        """`xhigh` is supported by the SDK Reasoning enum (post gpt-5.1-codex-max).
+        Config must accept it and the helper must forward it as-is."""
+        spec = ModelEndpointConfig(
+            name="openai/gpt-5-1-codex-max",
+            api_key="sk-test",
+            reasoning_effort="xhigh",
+        )
+        ms = ModelSettings()
+
+        apply_endpoint_model_settings(spec, ms)
+
+        assert ms.reasoning is not None
+        assert ms.reasoning.effort == "xhigh"
+
     def test_none_effort_is_grafted_explicitly(self):
         """`reasoning_effort='none'` is a meaningful value (gpt-5.1 default,
         gpt-oss "no thinking" mode), not the same as omitting the field."""
@@ -160,28 +190,33 @@ class TestApplyEndpointModelSettings:
 # ---------------------------------------------------------------------------
 
 
-@pytest.fixture
-def docker_dgx_like_config(tmp_path):
+@pytest.fixture(params=["responses", "chat_completions"])
+def docker_dgx_like_config(request, tmp_path):
     """Mirror configs/config-docker-dgx.yaml — every model on a vLLM endpoint
     with reasoning_effort/verbosity set, so we can prove every factory grafts
-    them onto its agent's ModelSettings."""
+    them onto its agent's ModelSettings.
+
+    Parametrized across both API dispatch paths (#164) so we cover the helper
+    against `OpenAIResponsesModel` (vLLM gpt-oss case) and
+    `OpenAIChatCompletionsModel` (legacy / llama.cpp default).
+    """
     config = Config(
-        config_name="test-docker-dgx",
+        config_name=f"test-docker-dgx-{request.param}",
         vector_store=VectorStoreConfig(name="test-vs"),
     )
-    vllm_endpoint = ModelEndpointConfig(
+    endpoint = ModelEndpointConfig(
         name="openai/gpt-oss-20b",
         base_url="http://vllm:8004/v1",
         api_key="dummy",
-        api="responses",
+        api=request.param,
         reasoning_effort="high",
         verbosity="medium",
     )
-    config.models.research_model = vllm_endpoint
-    config.models.planning_model = vllm_endpoint
-    config.models.search_model = vllm_endpoint
-    config.models.writer_model = vllm_endpoint
-    config.models.knowledge_preparation_model = vllm_endpoint
+    config.models.research_model = endpoint
+    config.models.planning_model = endpoint
+    config.models.search_model = endpoint
+    config.models.writer_model = endpoint
+    config.models.knowledge_preparation_model = endpoint
     config.agents.output_dir = str(tmp_path)
     config.agents.writer_output_format = "markdown"
     config.vector_search.provider = "chroma"
@@ -244,3 +279,38 @@ def test_qa_agent_grafts_reasoning_and_verbosity(docker_dgx_like_config):
         agent = mod.create_qa_agent()
 
     _assert_reasoning_and_verbosity_grafted(agent)
+
+
+def test_supervisor_agent_grafts_reasoning_and_verbosity(docker_dgx_like_config):
+    """The supervisor (`ResearchSupervisorAgent`) builds its own ModelSettings
+    from `config.models.research_model` — distinct path from the sub-agents
+    above, must also graft the per-endpoint controls."""
+    from src.agents import (
+        agentic_research_agent as supervisor_mod,
+    )
+    from src.agents import (
+        file_search_agent as search_mod,
+    )
+    from src.agents import (
+        file_search_planning_agent as planner_mod,
+    )
+    from src.agents import (
+        file_writer_agent as writer_mod,
+    )
+
+    with patch.object(planner_mod, "get_config", return_value=docker_dgx_like_config):
+        planner = planner_mod.create_file_planner_agent()
+    with patch.object(search_mod, "get_config", return_value=docker_dgx_like_config):
+        searcher = search_mod.create_file_search_agent(vector_store_id="vs_test")
+    with patch.object(writer_mod, "get_config", return_value=docker_dgx_like_config):
+        writer = writer_mod.create_writer_agent()
+
+    with patch.object(supervisor_mod, "get_config", return_value=docker_dgx_like_config):
+        supervisor = supervisor_mod.create_research_supervisor_agent(
+            mcp_servers=[],
+            file_planner_agent=planner,
+            file_search_agent=searcher,
+            writer_agent=writer,
+        )
+
+    _assert_reasoning_and_verbosity_grafted(supervisor)


### PR DESCRIPTION
## Summary

- New optional fields on `ModelEndpointConfig`: `reasoning_effort` (`none|low|medium|high`) and `verbosity` (`low|medium|high`).
- New helper `apply_endpoint_model_settings()` grafts them onto `ModelSettings.reasoning` / `.verbosity`. Wired into all 6 agent factories (planner, file_search, writer, knowledge_preparation, qa, supervisor).
- The SDK forwards them as-is via `OpenAIResponsesModel` (Responses API) or `OpenAIChatCompletionsModel` (Chat Completions).

## Design

- 4 levels for `reasoning_effort` — universal subset across gpt-oss (low/medium/high), o-series (low/medium/high), gpt-5.x (none/low/medium/high), Qwen 3.5+. Discussed in #170.
- 3 levels for `verbosity` — matches the SDK enum.
- **No adapter, no family detection** (YAGNI): one endpoint = one model in YAML; let the SDK forward the value and let the runtime fail loudly if a model doesn't support it.

## TDD

RED → GREEN, classic flow:
- 8 unit tests on `apply_endpoint_model_settings()` (pydantic + dict specs, `none` effort, no-op when fields absent, existing settings preserved).
- 5 factory integration tests confirming each agent grafts both fields when the endpoint config sets them.

## Test plan

- [x] `uv run pytest tests/test_reasoning_effort_verbosity.py` — 13/13 pass
- [x] `uv run pytest` — full suite green (no regression)
- [x] `uv run ruff check .` + `uv run ruff format --check .`
- [ ] Smoke test on DGX Spark: set `reasoning_effort: high` + `api: responses` on the gpt-oss endpoint and confirm vLLM emits the `reasoning` field

Fixes #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)